### PR TITLE
コントローラの入力を 2 player に分配

### DIFF
--- a/Omuct Fes 3D/Assets/GameMaster.cs
+++ b/Omuct Fes 3D/Assets/GameMaster.cs
@@ -48,6 +48,7 @@ public class GameMaster : MonoBehaviour,EventListener
         .SetUI(player1HPSlider,player1ItemImage)
         .SetTPSCamera(player1Camera)
         .MakeAvailable();
+        pl.SetPlayerIndex(0);
 
         this.playerR=Resources.Load<Player>(this.characterPaths[DataTransfer.player2CharacterNumber]);
         Player pr = Instantiate(playerR.gameObject,new Vector3(0f,10f,-10f),Quaternion.identity).GetComponent<Player>();
@@ -61,6 +62,7 @@ public class GameMaster : MonoBehaviour,EventListener
         .SetUI(player2HPSlider,player2ItemImage)
         .SetTPSCamera(player2Camera)
         .MakeAvailable();
+        pr.SetPlayerIndex(1);
 
         this.player1PoisonUI.player=pl;
         this.player2PoisonUI.player=pr;

--- a/Omuct Fes 3D/Assets/Input.meta
+++ b/Omuct Fes 3D/Assets/Input.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b5496207d8f517e4aa5a9ef329033ea8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Omuct Fes 3D/Assets/Input/PlayerController.cs
+++ b/Omuct Fes 3D/Assets/Input/PlayerController.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerController
+{
+
+    private PlayerDispenser.PlayerControllerInternal core;
+
+    public PlayerController(PlayerDispenser.PlayerControllerInternal core)
+    {
+        this.core = core;
+        this.core.beingUsed = true;
+    }
+
+    ~PlayerController()
+    {
+        this.core.beingUsed = false;
+    }
+
+    public Vector2 GetMoveValue()
+    {
+        return core.GetMoveValue();
+    }
+
+    public Vector2 GetCameraValue()
+    {
+        return core.GetCameraValue();
+    }
+
+}

--- a/Omuct Fes 3D/Assets/Input/PlayerController.cs
+++ b/Omuct Fes 3D/Assets/Input/PlayerController.cs
@@ -28,4 +28,19 @@ public class PlayerController
         return core.GetCameraValue();
     }
 
+    public bool GetUseItemValue()
+    {
+        return core.GetUseItemValue();
+    }
+
+    public bool GetAttack1Value()
+    {
+        return core.GetAttack1Value();
+    }
+
+    public bool GetJumpValue()
+    {
+        return core.GetJumpValue();
+    }
+
 }

--- a/Omuct Fes 3D/Assets/Input/PlayerController.cs.meta
+++ b/Omuct Fes 3D/Assets/Input/PlayerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f45b4ca71feff6444a99293a151bfb58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Omuct Fes 3D/Assets/Input/PlayerDispenser.cs
+++ b/Omuct Fes 3D/Assets/Input/PlayerDispenser.cs
@@ -1,0 +1,67 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class PlayerDispenser : MonoBehaviour
+{
+
+    // 1P, 2P を表すオブジェクトをフィールドにもつ
+    // メソッドで空いてるのを取得する
+    // 1P, 2P の入力を Update で更新
+
+    public class PlayerControllerInternal
+    {
+        public bool beingUsed;
+        private Gamepad gamepad;
+
+        public PlayerControllerInternal()
+        {
+            this.gamepad = null;
+            this.beingUsed = false;
+        }
+
+        public void SetGamePad(Gamepad gamepad)
+        {
+            this.gamepad = gamepad;
+        }
+
+        public Vector2 GetMoveValue()
+        {
+            if (gamepad is null) return Vector2.zero;
+            return gamepad.leftStick.ReadValue();
+        }
+
+        public Vector2 GetCameraValue()
+        {
+            if (gamepad is null) return Vector2.zero;
+            return gamepad.rightStick.ReadValue();
+        }
+    }
+
+    private static PlayerControllerInternal player0 = new PlayerControllerInternal();
+    private static PlayerControllerInternal player1 = new PlayerControllerInternal();
+
+    public PlayerController GetController(int playerid)
+    {
+        if (playerid == 0 && !(player0 is null) && !player0.beingUsed) return new PlayerController(player0);
+        if (playerid == 1 && !(player1 is null) && !player1.beingUsed) return new PlayerController(player1);
+        Debug.LogWarning("PlayerController GetController() returned null");
+        return null;
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        int gamepadCount = Gamepad.all.Count;
+        player0.SetGamePad(gamepadCount >= 1 ? Gamepad.all[0] : null);
+        player1.SetGamePad(gamepadCount >= 2 ? Gamepad.all[1] : null);
+    }
+
+
+}

--- a/Omuct Fes 3D/Assets/Input/PlayerDispenser.cs
+++ b/Omuct Fes 3D/Assets/Input/PlayerDispenser.cs
@@ -37,6 +37,24 @@ public class PlayerDispenser : MonoBehaviour
             if (gamepad is null) return Vector2.zero;
             return gamepad.rightStick.ReadValue();
         }
+
+        public bool GetUseItemValue()
+        {
+            if (gamepad is null) return false;
+            return gamepad.leftShoulder.isPressed;
+        }
+
+        public bool GetAttack1Value()
+        {
+            if (gamepad is null) return false;
+            return gamepad.rightShoulder.isPressed;
+        }
+
+        public bool GetJumpValue()
+        {
+            if (gamepad is null) return false;
+            return gamepad.buttonSouth.isPressed;
+        }
     }
 
     private static PlayerControllerInternal player0 = new PlayerControllerInternal();

--- a/Omuct Fes 3D/Assets/Input/PlayerDispenser.cs.meta
+++ b/Omuct Fes 3D/Assets/Input/PlayerDispenser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 215eda52d81e21e459f11ca74ac18998
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Omuct Fes 3D/Assets/Player.cs
+++ b/Omuct Fes 3D/Assets/Player.cs
@@ -114,37 +114,23 @@ abstract public class Player : MonoBehaviour
 
         if(IsAttackable)
             animator.SetTrigger("return");
-        
+
         //camera rotation
+        Vector2 cameraValue = playerController.GetCameraValue();
         float assistMagnification = Mathf.Pow(assistUnder,cursorDistance);
-        cameraRotation+=Mathf.Pow(Input.GetAxis(cameraHorizontalButton),3f)*0.005f*((isFocusTarget)?cameraRotationVelocityAssisted*assistMagnification:cameraRotationVelocity);
-        cameraRotationY=Mathf.Min(Mathf.Max(-verticalCameraLimit,cameraRotationY+
-        Mathf.Pow(Input.GetAxis(cameraVerticalButton),3f)
-        *0.01f*((isFocusTarget)?cameraRotationYVelocityAssisted*assistMagnification:cameraRotationYVelocity)),verticalCameraLimit);
+        cameraRotation += Mathf.Pow(cameraValue.x, 3f) * 0.005f * ((isFocusTarget) ? cameraRotationVelocityAssisted * assistMagnification : cameraRotationVelocity);
+        cameraRotationY = Mathf.Min(Mathf.Max(-verticalCameraLimit, cameraRotationY +
+        Mathf.Pow(cameraValue.y, 3f)
+        * 0.01f * ((isFocusTarget) ? cameraRotationYVelocityAssisted * assistMagnification : cameraRotationYVelocity)), verticalCameraLimit);
 
         //move
-        /*
-        move = cameraVec2*Input.GetAxis(moveVerticalButton)*horizontal
-        +new Vector3(
-            -Mathf.Sin(cameraRotation),
-            0,
-            Mathf.Cos(cameraRotation)
-            )*Input.GetAxis(moveHorizontalButton)*vertical;
-        if(move.magnitude>1.0f)
-            move=move.normalized;
-        move = move*move.magnitude;
-        if (move != Vector3.zero && !isAttacking)
-        {
-            gameObject.transform.forward = move;
-        }
-         */
-        Vector2 leftStickValue = playerController.GetMoveValue();
-        move = cameraVec2 * leftStickValue.y * horizontal
+        Vector2 moveValue = playerController.GetMoveValue();
+        move = cameraVec2 * moveValue.y * horizontal
         + new Vector3(
             -Mathf.Sin(cameraRotation),
             0,
             Mathf.Cos(cameraRotation)
-            ) * leftStickValue.x * vertical;
+            ) * moveValue.x * vertical;
         if (move.magnitude > 1.0f)
             move = move.normalized;
         move = move * move.magnitude;
@@ -154,38 +140,42 @@ abstract public class Player : MonoBehaviour
         }
 
         //jump
-        if (Input.GetButtonDown(jumpButton) && groundedPlayer)
+        if (playerController.GetJumpValue() && groundedPlayer)
         {
-            JumpEvent e = new JumpEvent(this,this.jumpForce);
+            JumpEvent e = new JumpEvent(this, this.jumpForce);
             GameMaster.instance.OnJump(e);
-            if(e.isAvailable)
+            if (e.isAvailable)
                 playerVelocity.y += e.JumpForce;
         }
-        
+
         //attack
-        if(Input.GetButtonDown(attackButton)&&IsAttackable){
+        if (playerController.GetAttack1Value() && IsAttackable)
+        {
             animator.SetTrigger("attack");
             gameObject.transform.forward = cameraVec2;
-            AttackEvent e=new AttackEvent(this);
+            AttackEvent e = new AttackEvent(this);
             GameMaster.instance.OnAttack(e);
-            if(e.isAvailable){
+            if (e.isAvailable)
+            {
                 Attack();
                 isAttacking = true;
-                lastAttackTime=GameMaster.instance.gameTime;
+                lastAttackTime = GameMaster.instance.gameTime;
             }
         }
 
         //use item
-        if(Input.GetButtonDown(useItemButton)){
-            if(item!=null){
+        if (playerController.GetUseItemValue())
+        {
+            if (item != null)
+            {
                 item.Use(this);
-                item=null;
-                this.itemImage.sprite = Sprite.Create(this.noItemTexture, new Rect(0,0,this.noItemTexture.width,this.noItemTexture.height), Vector2.zero);
+                item = null;
+                this.itemImage.sprite = Sprite.Create(this.noItemTexture, new Rect(0, 0, this.noItemTexture.width, this.noItemTexture.height), Vector2.zero);
             }
         }
 
         //update ui
-        hpSlider.value=(float)hp/(float)maxHp;
+        hpSlider.value = (float)hp / (float)maxHp;
     }
 
     //内部の処理はコンスタントに行いたいので、ほぼ確実に毎秒50回実行してくれるFixedUpdateで行う。

--- a/Omuct Fes 3D/Assets/Player.cs
+++ b/Omuct Fes 3D/Assets/Player.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.InputSystem;
 
 abstract public class Player : MonoBehaviour
 {
@@ -92,13 +93,25 @@ abstract public class Player : MonoBehaviour
         toTargetVec=new Vector3(0,0,0);
     }
 
+    public int playerIndex = 0;
+    public PlayerController playerController = null;
+
+    public void SetPlayerIndex(int playerIndex)
+    {
+        this.playerIndex = playerIndex;
+        GameObject playerControllerObject = GameObject.Find("PlayerDispenser"); // suppose null
+        PlayerDispenser playerDispenser = playerControllerObject.GetComponent<PlayerDispenser>();
+        playerController = playerDispenser.GetController(playerIndex);
+    }
 
     //操作関係はUpdateで処理してる
     private void Update()
     {
         if(!isAvailable)
             return;
-        Debug.Log("aaa");
+
+        //Debug.Log("aaa");
+
         if(IsAttackable)
             animator.SetTrigger("return");
         
@@ -110,6 +123,7 @@ abstract public class Player : MonoBehaviour
         *0.01f*((isFocusTarget)?cameraRotationYVelocityAssisted*assistMagnification:cameraRotationYVelocity)),verticalCameraLimit);
 
         //move
+        /*
         move = cameraVec2*Input.GetAxis(moveVerticalButton)*horizontal
         +new Vector3(
             -Mathf.Sin(cameraRotation),
@@ -119,6 +133,21 @@ abstract public class Player : MonoBehaviour
         if(move.magnitude>1.0f)
             move=move.normalized;
         move = move*move.magnitude;
+        if (move != Vector3.zero && !isAttacking)
+        {
+            gameObject.transform.forward = move;
+        }
+         */
+        Vector2 leftStickValue = playerController.GetMoveValue();
+        move = cameraVec2 * leftStickValue.y * horizontal
+        + new Vector3(
+            -Mathf.Sin(cameraRotation),
+            0,
+            Mathf.Cos(cameraRotation)
+            ) * leftStickValue.x * vertical;
+        if (move.magnitude > 1.0f)
+            move = move.normalized;
+        move = move * move.magnitude;
         if (move != Vector3.zero && !isAttacking)
         {
             gameObject.transform.forward = move;

--- a/Omuct Fes 3D/Assets/Resources/Prefabs/Characters/ekipu.prefab
+++ b/Omuct Fes 3D/Assets/Resources/Prefabs/Characters/ekipu.prefab
@@ -476,14 +476,16 @@ MonoBehaviour:
   jumpForce: 15
   cameraRotationVelocity: -10
   cameraRotationVelocityAssisted: -1
-  cameraRotationYVelocity: 1
+  cameraRotationYVelocity: -1
   cameraRotationYVelocityAssisted: 0.1
-  horizontal: -1
+  horizontal: 1
   vertical: 1
   th: 0.05
   verticalCameraLimit: 0.7
   cameraDistance: 8
   attackInterval: 20
+  assistUnder: 1
+  playerIndex: 0
   attackObject: {fileID: 4358696385323467273, guid: 4e3cab90edf90324b9012a73be2c7bf7, type: 3}
   attackForce: 1500
 --- !u!1 &2734417882892927546

--- a/Omuct Fes 3D/Assets/Resources/Prefabs/Characters/monsuter.by-ikehara.prefab
+++ b/Omuct Fes 3D/Assets/Resources/Prefabs/Characters/monsuter.by-ikehara.prefab
@@ -348,14 +348,16 @@ MonoBehaviour:
   jumpForce: 15
   cameraRotationVelocity: -10
   cameraRotationVelocityAssisted: -1
-  cameraRotationYVelocity: 1
+  cameraRotationYVelocity: -1
   cameraRotationYVelocityAssisted: 0.1
-  horizontal: -1
+  horizontal: 1
   vertical: 1
   th: 0.2
   verticalCameraLimit: 0.7
   cameraDistance: 8
   attackInterval: 10
+  assistUnder: 1
+  playerIndex: 0
   attackObject: {fileID: 4214217276863292064, guid: 322cfc4209bb1174dbe686334ad43ddc, type: 3}
   attackForce: 1000
 --- !u!1 &2196317924424290529

--- a/Omuct Fes 3D/Assets/Scenes/BattleScene.unity
+++ b/Omuct Fes 3D/Assets/Scenes/BattleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028334, g: 0.22571328, b: 0.3069217, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1507,6 +1507,50 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 0}
+--- !u!1 &1333406118
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1333406120}
+  - component: {fileID: 1333406119}
+  m_Layer: 0
+  m_Name: PlayerDispenser
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1333406119
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1333406118}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 215eda52d81e21e459f11ca74ac18998, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1333406120
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1333406118}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3.31745, y: 5.1884036, z: -1.1599923}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 18
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1360181633
 GameObject:
   m_ObjectHideFlags: 0

--- a/Omuct Fes 3D/Packages/manifest.json
+++ b/Omuct Fes 3D/Packages/manifest.json
@@ -5,6 +5,7 @@
     "com.unity.ide.rider": "3.0.15",
     "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
+    "com.unity.inputsystem": "1.4.3",
     "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.4",

--- a/Omuct Fes 3D/Packages/packages-lock.json
+++ b/Omuct Fes 3D/Packages/packages-lock.json
@@ -62,6 +62,15 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.inputsystem": {
+      "version": "1.4.3",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.uielements": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.nuget.newtonsoft-json": {
       "version": "3.0.2",
       "depth": 2,

--- a/Omuct Fes 3D/ProjectSettings/ProjectSettings.asset
+++ b/Omuct Fes 3D/ProjectSettings/ProjectSettings.asset
@@ -698,7 +698,7 @@ PlayerSettings:
     m_VersionCode: 1
     m_VersionName: 
   apiCompatibilityLevel: 6
-  activeInputHandler: 0
+  activeInputHandler: 2
   cloudProjectId: 
   framebufferDepthMemorylessMode: 0
   qualitySettingsNames: []


### PR DESCRIPTION
- PC に 2 個のコントローラを接続したとき、 1P と 2P に入力を分配する。
- キーボードの入力は受け付けられない。
- 各要素のテスト時など、コントローラ 1 個で 1P のみプレイすることもできる。